### PR TITLE
Moved random generator to main scope.

### DIFF
--- a/smslibrary/src/main/java/com/eis/communication/RandomPeerGenerator.java
+++ b/smslibrary/src/main/java/com/eis/communication/RandomPeerGenerator.java
@@ -1,4 +1,4 @@
-package com.eis.smslibrary.random;
+package com.eis.communication;
 
 import com.eis.communication.Peer;
 

--- a/smslibrary/src/main/java/com/eis/smslibrary/RandomSMSPeerGenerator.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/RandomSMSPeerGenerator.java
@@ -1,8 +1,8 @@
-package com.eis.smslibrary.random;
+package com.eis.smslibrary;
 
 import androidx.annotation.NonNull;
 
-import com.eis.smslibrary.SMSPeer;
+import com.eis.communication.RandomPeerGenerator;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber;
 

--- a/smslibrary/src/test/java/com/eis/smslibrary/random/RandomSMSPeerGeneratorTest.java
+++ b/smslibrary/src/test/java/com/eis/smslibrary/random/RandomSMSPeerGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.eis.smslibrary.random;
 
+import com.eis.smslibrary.RandomSMSPeerGenerator;
 import com.eis.smslibrary.SMSPeer;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 


### PR DESCRIPTION
Due to the fact the peer generator is not accessible outside the library if compiled via jitpack, the classes have been moved to the main scope.